### PR TITLE
ws: Don't flash UI on websocket reconnect

### DIFF
--- a/js/console.js
+++ b/js/console.js
@@ -46,7 +46,7 @@ var velesDevConsole = {
                     autofocus: true,
                     welcomeMessage: velesDevConsole.welcomeMessage[velesSinglePageApp.language]
                 });
-                velesDevConsole.controller.promptText('.help');
+                velesDevConsole.controller.promptText('help');
             });
             // auto-focus when mouse over console
             $('#dev-console').mouseover(function() {


### PR DESCRIPTION
No need to rapidly hide and close bottom panel parts if we're just reconnecting for under a 3 seconds to avoid annoying effects.